### PR TITLE
add localization delegate and ja_JP button text.

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,11 +1,23 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:apple_sign_in_example/sign_in_page.dart';
+import 'package:apple_sign_in/apple_sign_in_localizations.dart';
 
 void main() => runApp(MyApp());
 
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(home: SignInPage());
+    return MaterialApp(
+      localizationsDelegates: [
+        const AppleSignInLocalizationsDelegate(),
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+      ],
+      supportedLocales: [
+        const Locale('ja'),
+      ],
+      home: SignInPage(),
+    );
   }
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -15,7 +15,7 @@ class MyApp extends StatelessWidget {
         GlobalWidgetsLocalizations.delegate,
       ],
       supportedLocales: [
-        const Locale('ja'),
+        const Locale('en', 'ja'),
       ],
       home: SignInPage(),
     );

--- a/lib/apple_sign_in_button.dart
+++ b/lib/apple_sign_in_button.dart
@@ -1,4 +1,7 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+
+import 'apple_sign_in_localizations.dart';
 
 /// A type for the authorization button.
 enum ButtonType { defaultButton, continueButton, signIn }
@@ -47,6 +50,11 @@ class _AppleSignInButtonState extends State<AppleSignInButton> {
     final borderColor =
         widget.style == ButtonStyle.white ? Colors.white : Colors.black;
 
+    final localization = AppleSignInLocalizations.of(context);
+    assert(localization != null);
+
+    final buttonText = widget.type == ButtonType.continueButton ? localization.continueButton : localization.defaultButton;
+
     return GestureDetector(
       onTapDown: (_) => setState(() => _isTapDown = true),
       onTapUp: (_) {
@@ -86,9 +94,7 @@ class _AppleSignInButtonState extends State<AppleSignInButton> {
               ),
             ),
             Text(
-              widget.type == ButtonType.continueButton
-                  ? 'Continue with Apple'
-                  : 'Sign in with Apple',
+              buttonText,
               style: TextStyle(
                 fontSize: 20,
                 fontWeight: FontWeight.w500,

--- a/lib/apple_sign_in_localizations.dart
+++ b/lib/apple_sign_in_localizations.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+class AppleSignInLocalizations {
+  AppleSignInLocalizations(this.locale);
+
+  final Locale locale;
+
+  static AppleSignInLocalizations of(BuildContext context) {
+    return Localizations.of<AppleSignInLocalizations>(context, AppleSignInLocalizations);
+  }
+
+  static Map<String, Map<String, String>> _localizedValues = {
+    // TODO add other languages
+    'en': {
+      'defaultButton': 'Sign in with Apple',
+      'continueButton': 'Continue with Apple',
+    },
+    'ja': {
+      'defaultButton': 'Appleでサインイン',
+      'continueButton': 'Appleで続ける',
+    },
+  };
+
+  String get defaultButton {
+    return _localizedValues[locale.languageCode]['defaultButton'];
+  }
+
+  String get continueButton {
+    return _localizedValues[locale.languageCode]['continueButton'];
+  }
+}
+
+class AppleSignInLocalizationsDelegate extends LocalizationsDelegate<AppleSignInLocalizations> {
+  const AppleSignInLocalizationsDelegate();
+
+  @override
+  bool isSupported(Locale locale) => ['en', 'ja'].contains(locale.languageCode);
+
+  @override
+  Future<AppleSignInLocalizations> load(Locale locale) {
+    return SynchronousFuture<AppleSignInLocalizations>(AppleSignInLocalizations(locale));
+  }
+
+  @override
+  bool shouldReload(AppleSignInLocalizationsDelegate old) => false;
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,11 @@ dependencies:
   flutter:
     sdk: flutter
 
+  flutter_localizations:
+    sdk: flutter
+
+  flutter_cupertino_localizations: ^1.0.1
+
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
Hi tom. i try localization this plugin for japanese.
please using this code, if looks good to you.

https://developer.apple.com/documentation/signinwithapplejs/incorporating_sign_in_with_apple_into_other_platforms